### PR TITLE
Fix/custom og

### DIFF
--- a/pages/seats/[[...seat]].tsx
+++ b/pages/seats/[[...seat]].tsx
@@ -3,6 +3,8 @@ import ElectionSeatsDashboard from "@dashboards/my-area/seats";
 import { get } from "@lib/api";
 import { withi18n } from "@lib/decorators";
 import { Page } from "@lib/types";
+import { useTranslation } from "@hooks/useTranslation";
+import { AnalyticsProvider } from "@lib/contexts/analytics";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { MapProvider } from "react-map-gl/mapbox";
 
@@ -13,12 +15,23 @@ import { MapProvider } from "react-map-gl/mapbox";
 
 const Home: Page = ({
   params,
+  meta,
   selection,
   seat,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const { t } = useTranslation("seats");
+  const currentSeat = selection.find(
+    (seats: any) => seats.slug === params.seat_name,
+  );
+
   return (
-    <>
-      <Metadata keywords="" />
+    <AnalyticsProvider meta={meta}>
+      <Metadata
+        title={currentSeat.seat_name}
+        description={t("hero.description", { ns: "seats" })}
+        image={`${process.env.NEXT_PUBLIC_API_URL_S3}/og-image/${params.seat_name}.png`}
+        keywords={`Malaysia, election, seats, dashboard, results, ${currentSeat?.seat_name || ""}, ${params.seat_name}, parlimen, DUN`}
+      />
       <MapProvider>
         <ElectionSeatsDashboard
           elections={seat.data}
@@ -33,7 +46,7 @@ const Home: Page = ({
           lineage={{ type: "parlimen", data: seat.lineage }}
         />
       </MapProvider>
-    </>
+    </AnalyticsProvider>
   );
 };
 

--- a/pages/seats/[[...seat]].tsx
+++ b/pages/seats/[[...seat]].tsx
@@ -29,7 +29,12 @@ const Home: Page = ({
       <Metadata
         title={currentSeat.seat_name}
         description={t("hero.description", { ns: "seats" })}
-        image={`${process.env.NEXT_PUBLIC_API_URL_S3}/og-image/${params.seat_name}.png`}
+        image={
+          // Sitewide OG for root /seats, custom OG only when a seat is selected
+          selection.length === 0
+            ? undefined // Sitewide OG
+            : `${process.env.NEXT_PUBLIC_API_URL_S3}/og-image/${params.seat_name}.png` // Custom OG
+        }
         keywords={`Malaysia, election, seats, dashboard, results, ${currentSeat?.seat_name || ""}, ${params.seat_name}, parlimen, DUN`}
       />
       <MapProvider>

--- a/pages/seats/[[...seat]].tsx
+++ b/pages/seats/[[...seat]].tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "@hooks/useTranslation";
 import { AnalyticsProvider } from "@lib/contexts/analytics";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { MapProvider } from "react-map-gl/mapbox";
+import { useRouter } from "next/router";
 
 /**
  * Seats Dashboard
@@ -20,19 +21,20 @@ const Home: Page = ({
   seat,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation("seats");
+  const router = useRouter();
   const currentSeat = selection.find(
     (seats: any) => seats.slug === params.seat_name,
   );
+  const isRootSeatsPath = router.asPath === "/seats";  // Check if path is /seats (root)
 
   return (
     <AnalyticsProvider meta={meta}>
       <Metadata
-        title={currentSeat.seat_name}
+        title={isRootSeatsPath ? "" : currentSeat.seat_name}
         description={t("hero.description", { ns: "seats" })}
         image={
-          // Sitewide OG for root /seats, custom OG only when a seat is selected
-          selection.length === 0
-            ? undefined // Sitewide OG
+          isRootSeatsPath
+            ? undefined // Sitewide OG for root /seats
             : `${process.env.NEXT_PUBLIC_API_URL_S3}/og-image/${params.seat_name}.png` // Custom OG
         }
         keywords={`Malaysia, election, seats, dashboard, results, ${currentSeat?.seat_name || ""}, ${params.seat_name}, parlimen, DUN`}


### PR DESCRIPTION
Re-added custom OG functionality to the Seats page, handling two cases:
- Use default sitewide OG if on root `/seats` path.
- Use custom map OG if on `/seats/{slug}`