### PR TITLE
Fix seats query, add explicit URL to redel page

### DIFF
--- a/dashboards/my-area/seats.tsx
+++ b/dashboards/my-area/seats.tsx
@@ -194,6 +194,10 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
     });
   };
 
+  const filteredElections = elections.filter(
+    (election) => !("change_en" in election),
+  );
+
   const seat_schema = generateSchema<Seat>([
     {
       key: "election_name",
@@ -219,8 +223,8 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
       header: "",
       cell: ({ row }) => (
         <FullResults
-          options={elections.filter((election) => !("change_en" in election))}
-          currentIndex={row.index}
+          options={filteredElections}
+          currentIndex={filteredElections.indexOf(row.original as Seat)}
           onChange={(option: Seat) =>
             fetchFullResult(
               option.election_name,

--- a/dashboards/redelineation/index.tsx
+++ b/dashboards/redelineation/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@govtechmy/myds-react/tooltip";
 import { useData } from "@hooks/useData";
 import { useTranslation } from "@hooks/useTranslation";
-import { clx } from "@lib/helpers";
+import { clx, seatSlug } from "@lib/helpers";
 import dynamic from "next/dynamic";
 import { FunctionComponent, useEffect } from "react";
 import {
@@ -33,6 +33,7 @@ import {
 import { routes } from "@lib/routes";
 import { useTheme } from "next-themes";
 import { Theme } from "@lib/types";
+import { useRouter } from "next/router";
 
 const Bar = dynamic(() => import("@charts/bar"), { ssr: false });
 const Mapbox = dynamic(() => import("@dashboards/redelineation/mapbox"), {
@@ -55,6 +56,8 @@ interface RedelineationProps {
     type: string;
     year: string;
     election_type: ElectionType;
+    toggle_state?: string | null;
+    seat_slug?: string | null;
   };
   yearOptions: yearOptions;
   data: RedelineationData;
@@ -70,12 +73,21 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
   const theme = (resolvedTheme || "light") as Theme;
 
   const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const { replace } = useRouter();
 
-  const { type, year, election_type } = params;
+  const { type, year, election_type, toggle_state: param_toggle, seat_slug } =
+    params;
+
+  const initial_toggle: ToggleState = (param_toggle as ToggleState) || "new";
+  const initial_seat = seat_slug
+    ? ((data[initial_toggle].find(
+        (d: any) => seatSlug(d[`seat_${initial_toggle}`]) === seat_slug,
+      ) as any)?.[`seat_${initial_toggle}`] ?? "")
+    : "";
 
   const { data: _data, setData } = useData({
-    seat_value: "",
-    toggle_state: "new" as ToggleState,
+    seat_value: initial_seat,
+    toggle_state: initial_toggle,
   });
 
   const { seat_value, toggle_state } = _data;
@@ -146,16 +158,31 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
   const { redelineation_map } = useMap();
 
   useEffect(() => {
-    setData("seat_value", current_seat[`seat_${toggle_state}`] as string);
+    const target_toggle: ToggleState =
+      (param_toggle as ToggleState) || "new";
+    const target_seat_value = seat_slug
+      ? ((data[target_toggle].find(
+          (d: any) => seatSlug(d[`seat_${target_toggle}`]) === seat_slug,
+        ) as any)?.[`seat_${target_toggle}`] ??
+        (data[target_toggle][0] as any)[`seat_${target_toggle}`])
+      : (data[target_toggle][0] as any)[`seat_${target_toggle}`];
+
+    setData("toggle_state", target_toggle);
+    setData("seat_value", target_seat_value);
+
+    const target_seat =
+      (data[target_toggle].find(
+        (d: any) => d[`seat_${target_toggle}`] === target_seat_value,
+      ) as any) || data[target_toggle][0];
 
     if (redelineation_map) {
       redelineation_map.flyTo({
-        center: current_seat.center,
-        zoom: current_seat.zoom,
+        center: target_seat.center,
+        zoom: target_seat.zoom,
         duration: 2000,
       });
 
-      if (toggle_state === "new") {
+      if (target_toggle === "new") {
         redelineation_map.moveLayer(`${data.map_new}-line`);
         redelineation_map.moveLayer(`${data.map_new}-fill`);
       } else {
@@ -170,6 +197,39 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
 
   const old_year =
     data["map_old"].split("_").find((part) => /^\d{4}$/.test(part)) || "";
+
+  const handleToggleChange = (value: string) => {
+    const newToggle = value as ToggleState;
+    setData("toggle_state", newToggle);
+
+    const newSeatValue = (
+      current_seat[`seat_${newToggle}`] as string[]
+    )[0];
+    setData("seat_value", newSeatValue);
+
+    if (seat_slug) {
+      replace(
+        `${routes.REDELINEATION}/${type}/${year}/${newToggle}/${seatSlug(newSeatValue)}`,
+        undefined,
+        { scroll: false },
+      );
+    }
+
+    if (redelineation_map) {
+      redelineation_map.flyTo({
+        center: current_seat.center,
+        zoom: current_seat.zoom,
+        duration: 2000,
+      });
+      if (newToggle === "new") {
+        redelineation_map.moveLayer(`${data.map_new}-line`);
+        redelineation_map.moveLayer(`${data.map_new}-fill`);
+      } else {
+        redelineation_map.moveLayer(`${data.map_old}-line`);
+        redelineation_map.moveLayer(`${data.map_old}-fill`);
+      }
+    }
+  };
 
   return (
     <>
@@ -201,30 +261,7 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
               variant="enclosed"
               className="space-y-6 lg:space-y-8"
               value={toggle_state}
-              onValueChange={(value) => {
-                setData("toggle_state", value as "new" | "old");
-
-                setData(
-                  "seat_value",
-                  current_seat[`seat_${value as "old" | "new"}`][0],
-                );
-
-                if (redelineation_map) {
-                  redelineation_map.flyTo({
-                    center: current_seat.center,
-                    zoom: current_seat.zoom,
-                    duration: 2000,
-                  });
-
-                  if (value === "new") {
-                    redelineation_map.moveLayer(`${data.map_new}-line`);
-                    redelineation_map.moveLayer(`${data.map_new}-fill`);
-                  } else {
-                    redelineation_map.moveLayer(`${data.map_old}-line`);
-                    redelineation_map.moveLayer(`${data.map_old}-fill`);
-                  }
-                }
-              }}
+              onValueChange={handleToggleChange}
             >
               <TabsList className="mx-auto space-x-0 !py-0">
                 <TabsTrigger value="new" className="">
@@ -263,14 +300,26 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
                   onChange={(selected) => {
                     if (selected) {
                       setData("seat_value", selected.value);
-                      if (!redelineation_map) return;
-
-                      redelineation_map.flyTo({
-                        center: selected.center,
-                        zoom: selected.zoom,
-                        duration: 1500,
-                      });
-                    } else setData("seat_value", "");
+                      replace(
+                        `${routes.REDELINEATION}/${type}/${year}/${toggle_state}/${seatSlug(selected.value)}`,
+                        undefined,
+                        { scroll: false },
+                      );
+                      if (redelineation_map) {
+                        redelineation_map.flyTo({
+                          center: selected.center,
+                          zoom: selected.zoom,
+                          duration: 1500,
+                        });
+                      }
+                    } else {
+                      setData("seat_value", "");
+                      replace(
+                        `${routes.REDELINEATION}/${type}/${year}/${election_type}`,
+                        undefined,
+                        { scroll: false },
+                      );
+                    }
                   }}
                 />
               </div>
@@ -278,9 +327,9 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
                 <div className="relative mx-auto flex h-[400px] w-full items-center justify-center overflow-hidden rounded-lg border border-otl-gray-200 lg:h-[400px] lg:w-[846px]">
                   <Mapbox
                     initialState={{
-                      longitude: data[toggle_state][0].center[0],
-                      latitude: data[toggle_state][0].center[1],
-                      zoom: data[toggle_state][0].zoom,
+                      longitude: current_seat.center[0],
+                      latitude: current_seat.center[1],
+                      zoom: current_seat.zoom,
                     }}
                     toggle_state={toggle_state}
                     sources={
@@ -345,28 +394,7 @@ const RedelineationDashboard: FunctionComponent<RedelineationProps> = ({
               variant="enclosed"
               className="space-y-6 lg:space-y-8"
               value={toggle_state}
-              onValueChange={(value) => {
-                setData("toggle_state", value as "new" | "old");
-                setData(
-                  "seat_value",
-                  current_seat[`seat_${value as "old" | "new"}`][0],
-                );
-
-                if (redelineation_map) {
-                  redelineation_map.flyTo({
-                    center: current_seat.center,
-                    zoom: current_seat.zoom,
-                    duration: 2000,
-                  });
-                  if (value === "new") {
-                    redelineation_map.moveLayer(`${data.map_new}-line`);
-                    redelineation_map.moveLayer(`${data.map_new}-fill`);
-                  } else {
-                    redelineation_map.moveLayer(`${data.map_old}-line`);
-                    redelineation_map.moveLayer(`${data.map_old}-fill`);
-                  }
-                }
-              }}
+              onValueChange={handleToggleChange}
             >
               <TabsList className="mx-auto space-x-0 !py-0">
                 <TabsTrigger value="new" className="">

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react";
 
 export function useMediaQuery(query: string) {
-  const [value, setValue] = useState(
-    () => typeof window !== "undefined" && matchMedia(query).matches,
-  );
+  const [value, setValue] = useState(false);
 
   useEffect(() => {
     function onChange(event: MediaQueryListEvent) {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -306,17 +306,14 @@ export const getTopIndices = (
 };
 
 /**
- * Slugify a given string
- * @param value String to slugify
+ * Slugify a seat name for use in URLs (removes dots/apostrophes, replaces spaces with dashes)
+ * @param name Seat name to slugify
  */
-export const slugify = (value: string): string => {
-  return value
-    .trim()
+export const seatSlug = (name: string) =>
+  name
     .toLowerCase()
-    .replace(/[^a-z0-9 ]/g, "") // remove all chars not letters, numbers and spaces (to be replaced)
-    .replace(/\s+/g, "-") // separator
-    .replace(/-+/g, "-"); // collapse dashes
-};
+    .replace(/[.']/g, "")
+    .replace(/\s+/g, "-");
 
 /**
  * Generic download helper function

--- a/pages/redelineation/[[...explorer]].tsx
+++ b/pages/redelineation/[[...explorer]].tsx
@@ -3,6 +3,7 @@ import RedelineationDashboard from "@dashboards/redelineation";
 import { useTranslation } from "@hooks/useTranslation";
 import { get } from "@lib/api";
 import { withi18n } from "@lib/decorators";
+import { seatSlug } from "@lib/helpers";
 import { Page } from "@lib/types";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { MapProvider } from "react-map-gl/mapbox";
@@ -24,11 +25,7 @@ const RedelineationIndex: Page = ({
       />
       <MapProvider>
         <RedelineationDashboard
-          params={{
-            type: params.explorer?.[0] || "peninsular",
-            year: params.explorer?.[1] || "2018",
-            election_type: params.explorer?.[2] || "parlimen",
-          }}
+          params={params}
           yearOptions={yearOptions}
           data={data}
         />
@@ -48,11 +45,29 @@ export const getStaticProps: GetStaticProps = withi18n(
   ["redelineation", "home"],
   async ({ params }) => {
     try {
-      const [type, year, election_type] = params?.explorer
-        ? (params.explorer as string[])
-        : ["peninsular", "2018", "parlimen"];
+      const explorer = params?.explorer as string[] | undefined;
+
+      let type: string, year: string, election_type: string;
+      let toggle_state: string | null = null;
+      let seat_slug: string | null = null;
+
+      if (!explorer || explorer.length === 0) {
+        type = "peninsular";
+        year = "2018";
+        election_type = "parlimen";
+      } else if (explorer.length === 3) {
+        [type, year, election_type] = explorer;
+      } else if (explorer.length === 4) {
+        // area/year/toggle/seat-slug — infer election_type from slug prefix
+        [type, year, toggle_state, seat_slug] = explorer;
+        election_type = seat_slug.startsWith("n") ? "dun" : "parlimen";
+      } else {
+        return { notFound: true };
+      }
 
       if (!type || !year || !election_type) return { notFound: true };
+      if (toggle_state && !["new", "old"].includes(toggle_state))
+        return { notFound: true };
 
       const results = await Promise.allSettled([
         get(`/redelineation/${type}_${year}_${election_type}.json`),
@@ -64,13 +79,21 @@ export const getStaticProps: GetStaticProps = withi18n(
         else return e.value.data;
       });
 
+      // Validate seat slug exists in data
+      if (seat_slug && toggle_state) {
+        const found = data[toggle_state]?.find(
+          (d: any) => seatSlug(d[`seat_${toggle_state}`]) === seat_slug,
+        );
+        if (!found) return { notFound: true };
+      }
+
       return {
         props: {
           meta: {
             id: "redelineation",
             type: "dashboard",
           },
-          params,
+          params: { type, year, election_type, toggle_state, seat_slug },
           yearOptions,
           data,
         },


### PR DESCRIPTION
1. Fixed bug on seats page which called the wrong detailed result in cases where there were additional rows narrating boundary changes.
2. Added explicit URL to redelineation page to increase shareability + enable (e.g.) custom OG.