### PR TITLE
Feat: Site metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ yarn-error.log*
 # local env files
 .env
 .env*.local
+.env.astro
+.env.next
 
 # vercel
 .vercel

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -40,7 +40,7 @@ const LayoutFooter = () => {
       title: t("footer.about"),
       links: [
         { label: t("footer.background"), href: "/about" },
-        { label: t("footer.site_metrics"), href: "#" },
+        { label: t("footer.site_metrics"), href: "/site-metrics" },
         { label: t("footer.documentation"), href: "/research" },
       ],
     },

--- a/dashboards/query-builder/index.tsx
+++ b/dashboards/query-builder/index.tsx
@@ -21,6 +21,8 @@ import {
   CheckCircleIcon,
   ClipboardDocumentIcon,
   ClipboardDocumentCheckIcon,
+  ClipboardIcon,
+  TrashIcon,
   WrenchScrewdriverIcon,
   SparklesIcon,
   PencilSquareIcon,
@@ -814,6 +816,26 @@ export default function QueryBuilderDashboard() {
     setTimeout(() => setCopyState("idle"), 2000);
   }, [activeQueryText]);
 
+  const handleClear = useCallback(() => {
+    clearShareParamsFromUrl();
+    setQueryText("");
+    setActiveSource("workspace");
+    setActiveSample(null);
+    setShortQueryId(null);
+    setShortenError(null);
+  }, [clearShareParamsFromUrl]);
+
+  const handlePaste = useCallback(async () => {
+    const text = await navigator.clipboard.readText();
+    if (!text.trim()) return;
+    clearShareParamsFromUrl();
+    setQueryText(text);
+    setActiveSource("workspace");
+    setActiveSample(null);
+    setShortQueryId(null);
+    setShortenError(null);
+  }, [clearShareParamsFromUrl]);
+
   const handleCopyPrompt = useCallback(async () => {
     await navigator.clipboard.writeText(copyPrompt);
     setPromptCopyState("copied");
@@ -1146,10 +1168,25 @@ export default function QueryBuilderDashboard() {
                       Format
                     </button>
                     <button
-                      onClick={handleCopy}
+                      onClick={handleClear}
+                      disabled={!activeQueryText.trim()}
+                      className="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium text-txt-black-700 transition-colors hover:bg-bg-washed-active disabled:opacity-40"
+                    >
+                      <TrashIcon className="h-3.5 w-3.5" />
+                      Clear
+                    </button>
+                    <button
+                      onClick={() => void handlePaste()}
+                      className="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium text-txt-black-700 transition-colors hover:bg-bg-washed-active"
+                    >
+                      <ClipboardIcon className="h-3.5 w-3.5" />
+                      Paste
+                    </button>
+                    <button
+                      onClick={() => void handleCopy()}
                       disabled={!activeQueryText.trim()}
                       title={copyState === "copied" ? "Copied!" : "Copy SQL"}
-                      className="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium text-txt-black-500 transition-colors hover:bg-bg-washed-active disabled:opacity-40"
+                      className="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium text-txt-black-700 transition-colors hover:bg-bg-washed-active disabled:opacity-40"
                     >
                       {copyState === "copied" ? (
                         <>

--- a/dashboards/site-metrics/MetricPanel.tsx
+++ b/dashboards/site-metrics/MetricPanel.tsx
@@ -1,0 +1,185 @@
+import { COLOR } from "@lib/constants";
+import { clx } from "@lib/helpers";
+import { Line } from "react-chartjs-2";
+import type { ChartOptions } from "chart.js";
+import { DateTime } from "luxon";
+import type { MetricKey, SiteMetricsRow } from "./types";
+import { formatAxis, formatDaily, formatTotal, rowValue, toUtcIso } from "./utils";
+
+const MAX_X_TICKS = 6;
+const GRID_COLOR = "rgba(128,128,128,0.15)";
+
+type MetricPanelProps = {
+  title: string;
+  dailyLabel: string;
+  totalLabel: string;
+  metricKey: MetricKey;
+  rows: SiteMetricsRow[];
+  daily: number;
+  total: number;
+  color: string;
+  colorH: string;
+  loading: boolean;
+  mounted: boolean;
+  chartOptions: ChartOptions<"line">;
+};
+
+export default function MetricPanel({
+  title,
+  dailyLabel,
+  totalLabel,
+  metricKey,
+  rows,
+  daily,
+  total,
+  color,
+  colorH,
+  loading,
+  mounted,
+  chartOptions,
+}: MetricPanelProps) {
+  const hasData = rows.length > 0;
+
+  return (
+    <div className="flex min-h-0 flex-col bg-bg-white p-3 lg:h-full lg:p-3">
+      <div className="shrink-0">
+        <h2 className="text-body-lg font-semibold text-txt-black-900">
+          {title}
+        </h2>
+        <div className="mt-1.5 flex gap-6">
+          <div>
+            <p className="text-body-xs text-txt-black-500">{dailyLabel}</p>
+            <p className="font-heading text-body-lg font-semibold text-txt-black-900">
+              {loading ? "—" : formatDaily(daily)}
+            </p>
+          </div>
+          <div>
+            <p className="text-body-xs text-txt-black-500">{totalLabel}</p>
+            <p className="font-heading text-body-lg font-semibold text-txt-black-900">
+              {loading ? "—" : formatTotal(total)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative mt-3 min-h-0 w-full flex-1 max-lg:h-[min(42svh,13rem)] lg:mt-2">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-body-sm text-txt-black-500">
+            …
+          </div>
+        ) : mounted && hasData ? (
+          <Line
+            data={{
+              datasets: [
+                {
+                  label: title,
+                  data: rows.map((row) => ({
+                    x: toUtcIso(`${row["timeseries.date"]} 00:00:00`),
+                    y: rowValue(row, metricKey),
+                  })),
+                  borderColor: color,
+                  backgroundColor: colorH,
+                  borderWidth: 1,
+                  pointRadius: 0,
+                  pointHoverRadius: 3,
+                  fill: true,
+                  tension: 0.2,
+                },
+              ],
+            }}
+            options={chartOptions}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-body-sm text-txt-black-500">
+            —
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const ROW_COLORS = [
+  { color: COLOR.PRIMARY, colorH: COLOR.PRIMARY_H },
+  { color: COLOR.PRIMARY, colorH: COLOR.PRIMARY_H },
+  { color: COLOR.PRIMARY, colorH: COLOR.PRIMARY_H },
+  { color: COLOR.DANGER, colorH: COLOR.DANGER_H },
+  { color: COLOR.DANGER, colorH: COLOR.DANGER_H },
+  { color: COLOR.DANGER, colorH: COLOR.DANGER_H },
+] as const;
+
+function buildXTickValues(min: number, max: number): number[] {
+  const range = max - min;
+  if (!Number.isFinite(range) || range <= 0) return [max];
+
+  const step = range / (MAX_X_TICKS - 1);
+  return Array.from({ length: MAX_X_TICKS }, (_, i) =>
+    i === MAX_X_TICKS - 1 ? max : min + step * i,
+  );
+}
+
+function formatXLabel(ms: number): string {
+  return DateTime.fromMillis(ms, { zone: "utc" }).toFormat("d MMM");
+}
+
+export function buildChartOptions(): ChartOptions<"line"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 600, easing: "easeInOutSine" },
+    transitions: { resize: { animation: { duration: 0 } } },
+    interaction: { mode: "index", intersect: false },
+    layout: {
+      padding: { top: 2, bottom: 4, left: 0, right: 2 },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx) =>
+            `${ctx.dataset.label}: ${formatAxis(ctx.parsed.y ?? 0)}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        type: "time",
+        time: {
+          unit: "day",
+          round: "day",
+          displayFormats: { day: "d MMM" },
+          tooltipFormat: "d MMM yyyy",
+        },
+        grid: { display: false, drawBorder: false },
+        afterBuildTicks: (scale) => {
+          const values = buildXTickValues(scale.min, scale.max);
+          scale.ticks = values.map((value) => ({
+            value,
+            label: formatXLabel(value),
+          }));
+        },
+        ticks: {
+          source: "labels",
+          autoSkip: false,
+          maxRotation: 0,
+          color: COLOR.DIM,
+          font: { size: 12, family: "Inter" },
+        },
+      },
+      y: {
+        beginAtZero: true,
+        grid: {
+          color: GRID_COLOR,
+          borderDash: [4, 4],
+          drawBorder: false,
+        },
+        ticks: {
+          maxTicksLimit: 6,
+          color: COLOR.DIM,
+          font: { size: 12, family: "Inter" },
+          callback: (value) => formatAxis(value),
+        },
+      },
+    },
+  };
+}

--- a/dashboards/site-metrics/MetricRow.tsx
+++ b/dashboards/site-metrics/MetricRow.tsx
@@ -1,0 +1,83 @@
+import { clx } from "@lib/helpers";
+import type { ChartOptions } from "chart.js";
+import { Line } from "react-chartjs-2";
+import type { MetricKey, SiteMetricsRow } from "./types";
+import { formatDaily, formatTotal, rowValue } from "./utils";
+
+type Props = {
+  title: string;
+  metricKey: MetricKey;
+  rows: SiteMetricsRow[];
+  daily: number;
+  total: number;
+  color: string;
+  colorH: string;
+  loading: boolean;
+  mounted: boolean;
+};
+
+const SPARKLINE_OPTS: ChartOptions<"line"> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  animation: { duration: 0 },
+  plugins: { legend: { display: false }, tooltip: { enabled: false } },
+  scales: {
+    x: { type: "linear", display: false },
+    y: { display: false, beginAtZero: true },
+  },
+  layout: { padding: { top: 2, bottom: 2, left: 0, right: 0 } },
+};
+
+export default function MetricRow({
+  title,
+  metricKey,
+  rows,
+  daily,
+  total,
+  color,
+  colorH,
+  loading,
+  mounted,
+}: Props) {
+  const hasData = rows.length > 0;
+
+  return (
+    <div className="grid grid-cols-[1fr_4rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-4 last:border-b-0">
+      <span className="text-body-sm font-medium text-txt-black-900">{title}</span>
+
+      <div className="relative h-12">
+        {!loading && mounted && hasData && (
+          <Line
+            data={{
+              datasets: [
+                {
+                  data: rows.map((row, i) => ({ x: i, y: rowValue(row, metricKey) })),
+                  borderColor: color,
+                  backgroundColor: colorH,
+                  borderWidth: 1.5,
+                  pointRadius: 0,
+                  fill: true,
+                  tension: 0.3,
+                },
+              ],
+            }}
+            options={SPARKLINE_OPTS}
+          />
+        )}
+      </div>
+
+      <span
+        className={clx(
+          "text-right text-body-sm font-semibold tabular-nums",
+          loading ? "text-txt-black-300" : "text-txt-black-900",
+        )}
+      >
+        {loading ? "—" : formatDaily(daily)}
+      </span>
+
+      <span className="text-right text-body-sm font-semibold text-txt-black-900 tabular-nums">
+        {loading ? "—" : formatTotal(total)}
+      </span>
+    </div>
+  );
+}

--- a/dashboards/site-metrics/index.tsx
+++ b/dashboards/site-metrics/index.tsx
@@ -1,0 +1,229 @@
+import { useTranslation } from "@hooks/useTranslation";
+import { clx } from "@lib/helpers";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  TimeScale,
+  Tooltip,
+} from "chart.js";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import MetricPanel, { ROW_COLORS, buildChartOptions } from "./MetricPanel";
+import MetricRow from "./MetricRow";
+import { DATE_FROM, METRICS, PERIODS, type Period, type SiteMetricsRow } from "./types";
+import { dailyCallout, metricTotal } from "./utils";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  TimeScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+  Filler,
+);
+
+const TB_BASE = process.env.NEXT_PUBLIC_API_URL_TB ?? "";
+
+function RefreshIcon({ spinning }: { spinning: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={clx("size-4", spinning && "animate-spin")}
+    >
+      <path
+        fillRule="evenodd"
+        d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H3.989a.75.75 0 0 0-.75.75v4.242a.75.75 0 0 0 1.5 0v-2.43l.31.31a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39Zm1.23-3.723a.75.75 0 0 0 .219-.53V2.929a.75.75 0 0 0-1.5 0V5.36l-.31-.31A7 7 0 0 0 3.239 8.188a.75.75 0 1 0 1.448.389A5.5 5.5 0 0 1 13.89 6.11l.311.31h-2.432a.75.75 0 0 0 0 1.5h4.243a.75.75 0 0 0 .53-.219Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function PeriodPills({
+  period,
+  setPeriod,
+  loading,
+  fetchData,
+  t,
+}: {
+  period: Period;
+  setPeriod: (p: Period) => void;
+  loading: boolean;
+  fetchData: () => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex rounded-lg border border-otl-gray-200 p-0.5">
+        {PERIODS.map((p) => (
+          <button
+            key={p}
+            onClick={() => setPeriod(p)}
+            className={clx(
+              "rounded-md px-3 py-1 text-body-sm font-medium transition",
+              period === p
+                ? "bg-bg-black-900 text-txt-white"
+                : "text-txt-black-500 hover:text-txt-black-900",
+            )}
+          >
+            {t(`period.${p}`)}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={fetchData}
+        disabled={loading}
+        aria-label="Refresh"
+        className="flex size-8 items-center justify-center rounded-lg border border-otl-gray-200 text-txt-black-500 transition hover:text-txt-black-900 disabled:opacity-40"
+      >
+        <RefreshIcon spinning={loading} />
+      </button>
+    </div>
+  );
+}
+
+export default function SiteMetricsDashboard() {
+  const { t } = useTranslation("site-metrics");
+  const [mounted, setMounted] = useState(false);
+  const [period, setPeriod] = useState<Period>("30d");
+  const [allRows, setAllRows] = useState<SiteMetricsRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    import("chartjs-adapter-luxon");
+    setMounted(true);
+  }, []);
+
+  const fetchData = useCallback(() => {
+    const token = process.env.NEXT_PUBLIC_TINYBIRD_TOKEN;
+    const url = `${TB_BASE}/v0/pipes/site_metrics.json?token=${token}&date_from=${DATE_FROM}`;
+
+    setLoading(true);
+    setError(null);
+
+    fetch(url)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load site metrics");
+        return r.json();
+      })
+      .then((json) => setAllRows(json?.data ?? []))
+      .catch((e) => {
+        setAllRows([]);
+        setError(e instanceof Error ? e.message : "Failed to load site metrics");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const rows = useMemo(() => {
+    if (period === "all") return allRows;
+    const days: Record<Exclude<Period, "all">, number> = { "7d": 7, "30d": 30, "90d": 90 };
+    const d = new Date();
+    d.setDate(d.getDate() - days[period]);
+    const cutoff = d.toISOString().slice(0, 10);
+    return allRows.filter((row) => row["timeseries.date"] >= cutoff);
+  }, [allRows, period]);
+
+  const chartOptions = useMemo(() => buildChartOptions(), []);
+
+  const pillsProps = { period, setPeriod, loading, fetchData, t };
+
+  return (
+    <div className="w-full px-4.5 md:px-6">
+      <div className="mx-auto w-full max-w-screen-xl">
+        {error && (
+          <p className="py-3 text-center text-body-sm text-txt-danger">{error}</p>
+        )}
+
+        {/* ── Mobile layout ── */}
+        <div className="lg:hidden pb-8">
+          <div className="flex flex-col items-center gap-3 px-3 py-6">
+            <h1 className="font-heading text-heading-sm font-semibold text-txt-black-900">
+              {t("meta.title")}
+            </h1>
+            <PeriodPills {...pillsProps} />
+          </div>
+
+          <div>
+            <div className="grid grid-cols-[1fr_4rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-2">
+              <span />
+              <span className="text-center text-xs font-semibold uppercase tracking-wider text-txt-black-400">
+                {t("trend")}
+              </span>
+              <span className="text-right text-xs font-semibold uppercase tracking-wider text-txt-black-400">
+                {t("daily")}
+              </span>
+              <span className="text-right text-xs font-semibold uppercase tracking-wider text-txt-black-400">
+                {t("total")}
+              </span>
+            </div>
+
+            {METRICS.map((metric, index) => {
+              const { color, colorH } = ROW_COLORS[index];
+              return (
+                <MetricRow
+                  key={metric.key}
+                  title={t(metric.labelKey)}
+                  metricKey={metric.key}
+                  rows={rows}
+                  daily={dailyCallout(rows, metric.key)}
+                  total={metricTotal(rows, metric.key)}
+                  color={color}
+                  colorH={colorH}
+                  loading={loading}
+                  mounted={mounted}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Desktop layout ── */}
+        <div className="hidden lg:flex lg:h-[calc(100svh-4rem)] lg:w-full lg:flex-col">
+          <div className="flex flex-col items-center gap-3 px-3 py-6">
+            <h1 className="font-heading text-heading-sm font-semibold text-txt-black-900">
+              {t("meta.title")}
+            </h1>
+            <PeriodPills {...pillsProps} />
+          </div>
+
+          <div className="grid min-h-0 flex-1 grid-cols-3 grid-rows-2">
+            {METRICS.map((metric, index) => {
+              const { color, colorH } = ROW_COLORS[index];
+              return (
+                <div key={metric.key} className="flex min-h-0 flex-col">
+                  <MetricPanel
+                    title={t(metric.labelKey)}
+                    dailyLabel={t("daily")}
+                    totalLabel={t("total")}
+                    metricKey={metric.key}
+                    rows={rows}
+                    daily={dailyCallout(rows, metric.key)}
+                    total={metricTotal(rows, metric.key)}
+                    color={color}
+                    colorH={colorH}
+                    loading={loading}
+                    mounted={mounted}
+                    chartOptions={chartOptions}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboards/site-metrics/types.ts
+++ b/dashboards/site-metrics/types.ts
@@ -1,0 +1,28 @@
+export type Period = "7d" | "30d" | "90d" | "all";
+export const PERIODS: Period[] = ["7d", "30d", "90d", "all"];
+
+export interface SiteMetricsRow {
+  "timeseries.date": string;
+  views: number;
+  queries: number;
+  downloads: number;
+  api_users: number | null;
+  api_hits: number;
+  lake_hits: number;
+}
+
+export type MetricKey = keyof Omit<SiteMetricsRow, "timeseries.date">;
+
+export const DATE_FROM = "2026-01-27";
+
+export const METRICS: {
+  key: MetricKey;
+  labelKey: string;
+}[] = [
+  { key: "views", labelKey: "chart.page_views" },
+  { key: "queries", labelKey: "chart.queries_built" },
+  { key: "downloads", labelKey: "chart.dataset_downloads" },
+  { key: "api_users", labelKey: "chart.api_users" },
+  { key: "api_hits", labelKey: "chart.api_hits" },
+  { key: "lake_hits", labelKey: "chart.data_lake_hits" },
+];

--- a/dashboards/site-metrics/utils.ts
+++ b/dashboards/site-metrics/utils.ts
@@ -1,0 +1,56 @@
+import { numFormat } from "@lib/helpers";
+import type { MetricKey, SiteMetricsRow } from "./types";
+
+// Tinybird returns timestamps as "YYYY-MM-DD HH:MM:SS"; Luxon needs ISO 8601 with T + timezone.
+export function toUtcIso(s: string): string {
+  const withT = s.replace(" ", "T");
+  return /[Zz]|[+-]\d{2}:?\d{2}$/.test(withT) ? withT : withT + "Z";
+}
+
+export function rowValue(row: SiteMetricsRow, key: MetricKey): number {
+  return row[key] ?? 0;
+}
+
+export function latestDaily(rows: SiteMetricsRow[], key: MetricKey): number {
+  if (!rows.length) return 0;
+  return rowValue(rows[rows.length - 1], key);
+}
+
+/** Daily callout value: latest day, or today − yesterday for cumulative api_users. */
+export function dailyCallout(rows: SiteMetricsRow[], key: MetricKey): number {
+  if (key === "api_users") {
+    if (rows.length < 2) return 0;
+    return (
+      rowValue(rows[rows.length - 1], key) -
+      rowValue(rows[rows.length - 2], key)
+    );
+  }
+  return latestDaily(rows, key);
+}
+
+export function metricTotal(rows: SiteMetricsRow[], key: MetricKey): number {
+  if (key === "api_users") {
+    return latestDaily(rows, key);
+  }
+  return rows.reduce((sum, row) => sum + rowValue(row, key), 0);
+}
+
+export function formatDaily(value: number): string {
+  const formatted = numFormat(
+    Math.abs(value),
+    "standard",
+    0,
+    "short",
+    "en-GB",
+  );
+  if (value < 0) return `-${formatted}`;
+  return `+${formatted}`;
+}
+
+export function formatTotal(value: number): string {
+  return numFormat(value, "standard", 0, "short", "en-GB");
+}
+
+export function formatAxis(value: number | string): string {
+  return numFormat(Number(value), "compact", 0, "short", "en-GB");
+}

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -13,6 +13,7 @@ export const routes = {
   PARTIES: "/parties",
   REDELINEATION: "/redelineation",
   RESEARCH: "/research",
+  SITE_METRICS: "/site-metrics",
   SEATS: "/seats",
   TRIVIA: "/trivia",
 };

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -16,6 +16,7 @@ const namespaces = [
   "redelineation",
   "research",
   "seats",
+  "site-metrics",
 ];
 
 /** @type {import('next-i18next').UserConfig} */
@@ -26,7 +27,18 @@ const defineConfig = (namespace, autoloadNs) => {
       locales: ["en-GB", "ms-MY"],
     },
     backend: {
-      loadPath: `${process.env.NEXT_PUBLIC_I18N_URL}/{{lng}}/{{ns}}.json`,
+      // Resolve at fetch time so NEXT_PUBLIC_I18N_URL from .env is always picked up.
+      loadPath: (lng, ns) => {
+        const locale = Array.isArray(lng) ? lng[0] : lng;
+        const namespace = Array.isArray(ns) ? ns[0] : ns;
+        const base = process.env.NEXT_PUBLIC_I18N_URL;
+        if (!base) {
+          throw new Error(
+            "NEXT_PUBLIC_I18N_URL is not set. Add it to .env (see .env.example).",
+          );
+        }
+        return `${base}/${locale}/${namespace}.json`;
+      },
       crossDomain: true,
       allowMultiLoading: true,
     },

--- a/pages/site-metrics.tsx
+++ b/pages/site-metrics.tsx
@@ -1,0 +1,30 @@
+import Metadata from "@components/Metadata";
+import SiteMetricsDashboard from "@dashboards/site-metrics";
+import { withi18n } from "@lib/decorators";
+import { Page } from "@lib/types";
+import { GetStaticProps } from "next";
+import { useTranslation } from "@hooks/useTranslation";
+
+const SiteMetricsPage: Page = () => {
+  const { t } = useTranslation("site-metrics");
+
+  return (
+    <>
+      <Metadata
+        title={t("meta.title")}
+        description={t("meta.description")}
+        keywords="ElectionData.MY, site metrics, analytics"
+      />
+      <SiteMetricsDashboard />
+    </>
+  );
+};
+
+export const getStaticProps: GetStaticProps = withi18n(
+  "site-metrics",
+  async () => ({
+    props: { meta: { id: "site-metrics", type: "misc" } },
+  }),
+);
+
+export default SiteMetricsPage;


### PR DESCRIPTION
Adds a new `/site-metrics` dashboard for viewing ElectionData.MY usage analytics. The page fetches Tinybird site metrics, supports 7-day, 30-day, 90-day, and all-time filters, and visualizes page views, query builder usage, downloads, API users, API hits, and data lake hits with responsive charts.

The commit also adds supporting metric utilities/types, registers the new route, wires the page into i18n via the site-metrics namespace, updates the footer link to point to /site-metrics, and improves i18n backend URL resolution.