### PR TITLE
Polish: Replace Chart.js sparklines with SVG in site metrics mobile view

### DIFF
--- a/components/Sparkline.tsx
+++ b/components/Sparkline.tsx
@@ -1,0 +1,32 @@
+type SparklineProps = {
+  values: number[];
+  color: string;
+  colorH: string;
+};
+
+export default function Sparkline({ values, color, colorH }: SparklineProps) {
+  if (values.length < 2) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const W = 100;
+  const H = 100;
+  const pad = 3;
+
+  const pts = values.map((v, i) => ({
+    x: (i / (values.length - 1)) * W,
+    y: H - pad - ((v - min) / range) * (H - pad * 2),
+  }));
+
+  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p.x},${p.y}`).join(" ");
+  const area = `${line} L${pts[pts.length - 1].x},${H} L${pts[0].x},${H} Z`;
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="h-full w-full">
+      <path d={area} fill={colorH} />
+      <path d={line} fill="none" stroke={color} strokeWidth="2" />
+    </svg>
+  );
+}

--- a/dashboards/site-metrics/MetricRow.tsx
+++ b/dashboards/site-metrics/MetricRow.tsx
@@ -1,6 +1,5 @@
 import { clx } from "@lib/helpers";
-import type { ChartOptions } from "chart.js";
-import { Line } from "react-chartjs-2";
+import Sparkline from "@components/Sparkline";
 import type { MetricKey, SiteMetricsRow } from "./types";
 import { formatDaily, formatTotal, rowValue } from "./utils";
 
@@ -16,18 +15,6 @@ type Props = {
   mounted: boolean;
 };
 
-const SPARKLINE_OPTS: ChartOptions<"line"> = {
-  responsive: true,
-  maintainAspectRatio: false,
-  animation: { duration: 0 },
-  plugins: { legend: { display: false }, tooltip: { enabled: false } },
-  scales: {
-    x: { type: "linear", display: false },
-    y: { display: false, beginAtZero: true },
-  },
-  layout: { padding: { top: 2, bottom: 2, left: 0, right: 0 } },
-};
-
 export default function MetricRow({
   title,
   metricKey,
@@ -39,30 +26,15 @@ export default function MetricRow({
   loading,
   mounted,
 }: Props) {
-  const hasData = rows.length > 0;
+  const values = rows.map((row) => rowValue(row, metricKey));
 
   return (
-    <div className="grid grid-cols-[1fr_4rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-4 last:border-b-0">
+    <div className="grid grid-cols-[1fr_4.5rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-4 last:border-b-0">
       <span className="text-body-sm font-medium text-txt-black-900">{title}</span>
 
-      <div className="relative h-12">
-        {!loading && mounted && hasData && (
-          <Line
-            data={{
-              datasets: [
-                {
-                  data: rows.map((row, i) => ({ x: i, y: rowValue(row, metricKey) })),
-                  borderColor: color,
-                  backgroundColor: colorH,
-                  borderWidth: 1.5,
-                  pointRadius: 0,
-                  fill: true,
-                  tension: 0.3,
-                },
-              ],
-            }}
-            options={SPARKLINE_OPTS}
-          />
+      <div className="h-12 w-full">
+        {!loading && mounted && values.length >= 2 && (
+          <Sparkline values={values} color={color} colorH={colorH} />
         )}
       </div>
 

--- a/dashboards/site-metrics/index.tsx
+++ b/dashboards/site-metrics/index.tsx
@@ -157,7 +157,7 @@ export default function SiteMetricsDashboard() {
           </div>
 
           <div>
-            <div className="grid grid-cols-[1fr_4rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-2">
+            <div className="grid grid-cols-[1fr_4.5rem_3rem_3.5rem] items-center gap-3 border-b border-otl-gray-100 px-4 py-2">
               <span />
               <span className="text-center text-xs font-semibold uppercase tracking-wider text-txt-black-400">
                 {t("trend")}


### PR DESCRIPTION
Fixes misalignment between the TREND header and sparklines caused by Chart.js sizing the canvas differently per data point count. Plain SVG with viewBox fills its container consistently regardless of period selection. Extracted as a reusable Sparkline component in /components.