### PR TITLE
Improve sign-in OTP input

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
       "fast-uri": "3.1.2",
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "webpack": "5.106.2",
-      "postcss": "8.5.14"
+      "postcss": "8.5.14",
+      "qs": "6.15.2"
     }
   }
 }

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -3,6 +3,7 @@ import { Button, Card } from "@components/index";
 import { withi18n } from "@lib/decorators";
 import { Page } from "@lib/types";
 import { clx } from "@lib/helpers";
+import { ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { GetStaticProps } from "next";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
@@ -10,17 +11,19 @@ import Script from "next/script";
 import Container from "@components/Container";
 
 const AUTH_URL = process.env.NEXT_PUBLIC_AUTH_URL ?? "/api/auth";
+const OTP_LENGTH = 8;
 
 const SignInPage: Page = () => {
   const router = useRouter();
   const [step, setStep] = useState<"email" | "otp">("email");
   const [email, setEmail] = useState("");
-  const [otp, setOtp] = useState("");
+  const [otp, setOtp] = useState<string[]>(() => Array(OTP_LENGTH).fill(""));
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [checkingSession, setCheckingSession] = useState(true);
   const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
   const [countdown, setCountdown] = useState(0);
+  const otpInputRefs = useRef<Array<HTMLInputElement | null>>([]);
 
   // Tick the countdown down every second while rate-limited
   useEffect(() => {
@@ -121,6 +124,8 @@ const SignInPage: Page = () => {
 
   const handleOtpSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const otpValue = otp.join("");
+    if (otpValue.length !== OTP_LENGTH) return;
     setError(null);
     setLoading(true);
     try {
@@ -128,7 +133,7 @@ const SignInPage: Page = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ email, otp }),
+        body: JSON.stringify({ email, otp: otpValue }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -143,6 +148,81 @@ const SignInPage: Page = () => {
       setLoading(false);
     }
   };
+
+  const resetOtp = () => setOtp(Array(OTP_LENGTH).fill(""));
+
+  const setOtpFromChars = (chars: string[]) => {
+    setOtp(chars.map((char) => char.replace(/\D/g, "").slice(0, 1)));
+    setError(null);
+  };
+
+  const focusOtpInput = (index: number) => {
+    otpInputRefs.current[Math.min(Math.max(index, 0), OTP_LENGTH - 1)]?.focus();
+  };
+
+  const applyOtpDigits = (value: string, startIndex = 0) => {
+    const digits = value.replace(/\D/g, "").slice(0, OTP_LENGTH);
+    if (!digits) return;
+
+    const chars = [...otp];
+    const offset = digits.length === OTP_LENGTH ? 0 : startIndex;
+    digits
+      .slice(0, OTP_LENGTH - offset)
+      .split("")
+      .forEach((digit, index) => {
+        chars[offset + index] = digit;
+      });
+
+    setOtpFromChars(chars);
+    focusOtpInput(offset + digits.length);
+  };
+
+  const handleOtpChange = (index: number, value: string) => {
+    const digits = value.replace(/\D/g, "");
+    if (digits.length > 1) {
+      applyOtpDigits(digits, index);
+      return;
+    }
+
+    const chars = [...otp];
+    chars[index] = digits;
+    setOtpFromChars(chars);
+
+    if (digits && index < OTP_LENGTH - 1) focusOtpInput(index + 1);
+  };
+
+  const handleOtpKeyDown = (
+    index: number,
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (e.key === "Backspace" && !otp[index] && index > 0) {
+      focusOtpInput(index - 1);
+    }
+    if (e.key === "ArrowLeft" && index > 0) {
+      e.preventDefault();
+      focusOtpInput(index - 1);
+    }
+    if (e.key === "ArrowRight" && index < OTP_LENGTH - 1) {
+      e.preventDefault();
+      focusOtpInput(index + 1);
+    }
+  };
+
+  const handlePasteOtp = async () => {
+    try {
+      const clipboardText = await navigator.clipboard.readText();
+      const digits = clipboardText.replace(/\D/g, "").slice(0, OTP_LENGTH);
+      if (!digits) {
+        setError("Clipboard does not contain a code.");
+        return;
+      }
+      applyOtpDigits(digits);
+    } catch {
+      setError("Unable to read from clipboard. Paste the code manually.");
+    }
+  };
+
+  const otpValue = otp.join("");
 
   return (
     <>
@@ -171,123 +251,160 @@ const SignInPage: Page = () => {
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-otl-gray-200 border-t-txt-black-900" />
               </div>
             ) : (
-            <>
-            <div className="mb-8 flex flex-col gap-2">
-              <h1 className="font-heading text-heading-sm font-semibold text-txt-black-900">
-                {step === "email" ? "Sign in" : "Check your email"}
-              </h1>
-              <p className="text-body-sm text-txt-black-700">
-                {step === "email"
-                  ? "Enter your email to receive a one-time passcode."
-                  : `We sent a code to ${email}. Enter it below to continue.`}
-              </p>
-            </div>
-
-            {step === "email" ? (
-              <form
-                onSubmit={handleEmailSubmit}
-                className="flex flex-col gap-4"
-              >
-                <div className="flex flex-col gap-1.5">
-                  <label
-                    htmlFor="email"
-                    className="text-body-sm font-medium text-txt-black-900"
-                  >
-                    Email address
-                  </label>
-                  <input
-                    id="email"
-                    type="email"
-                    required
-                    autoComplete="email"
-                    placeholder="you@example.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className={clx(
-                      "w-full rounded-md border px-3 py-2 text-body-sm text-txt-black-900",
-                      "bg-bg-white outline-none transition",
-                      "placeholder:text-txt-black-500",
-                      "focus:border-otl-gray-400 focus:ring-primary/20 focus:ring-2",
-                      error ? "border-txt-danger" : "border-otl-gray-200",
-                    )}
-                  />
+              <>
+                <div className="mb-8 flex flex-col gap-2">
+                  <h1 className="font-heading text-heading-sm font-semibold text-txt-black-900">
+                    {step === "email" ? "Sign in" : "Check your email"}
+                  </h1>
+                  <p className="text-body-sm text-txt-black-700">
+                    {step === "email"
+                      ? "Enter your email to receive a one-time passcode."
+                      : `We sent a code to ${email}. Enter it below to continue.`}
+                  </p>
                 </div>
 
-                {error && (
-                  <p className="text-body-sm text-txt-danger">{error}</p>
-                )}
-
-                {/* Invisible Turnstile widget */}
-                <div id="cf-turnstile" className="hidden" />
-
-                <Button
-                  type="submit"
-                  variant="primary"
-                  disabled={loading || !email || !!rateLimitedUntil}
-                  className="w-full justify-center py-2"
-                >
-                  {loading
-                    ? "Sending…"
-                    : rateLimitedUntil
-                    ? `Rate limited | Retry in ${countdown}s`
-                    : "Send code"}
-                </Button>
-              </form>
-            ) : (
-              <form onSubmit={handleOtpSubmit} className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1.5">
-                  <label
-                    htmlFor="otp"
-                    className="text-body-sm font-medium text-txt-black-900"
+                {step === "email" ? (
+                  <form
+                    onSubmit={handleEmailSubmit}
+                    className="flex flex-col gap-4"
                   >
-                    One-time passcode
-                  </label>
-                  <input
-                    id="otp"
-                    type="text"
-                    inputMode="numeric"
-                    required
-                    autoComplete="one-time-code"
-                    placeholder="11235813"
-                    value={otp}
-                    onChange={(e) => setOtp(e.target.value.replace(/\D/g, ""))}
-                    className={clx(
-                      "w-full rounded-md border px-3 py-2 font-mono tracking-widest text-body-sm text-txt-black-900",
-                      "bg-bg-white outline-none transition",
-                      "placeholder:text-txt-black-500",
-                      "focus:border-otl-gray-400 focus:ring-primary/20 focus:ring-2",
-                      error ? "border-txt-danger" : "border-otl-gray-200",
+                    <div className="flex flex-col gap-1.5">
+                      <label
+                        htmlFor="email"
+                        className="text-body-sm font-medium text-txt-black-900"
+                      >
+                        Email address
+                      </label>
+                      <input
+                        id="email"
+                        type="email"
+                        required
+                        autoComplete="email"
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className={clx(
+                          "w-full rounded-md border px-3 py-2 text-body-sm text-txt-black-900",
+                          "bg-bg-white outline-none transition",
+                          "placeholder:text-txt-black-500",
+                          "focus:border-otl-gray-400 focus:ring-primary/20 focus:ring-2",
+                          error ? "border-txt-danger" : "border-otl-gray-200",
+                        )}
+                      />
+                    </div>
+
+                    {error && (
+                      <p className="text-body-sm text-txt-danger">{error}</p>
                     )}
-                  />
-                </div>
 
-                {error && (
-                  <p className="text-body-sm text-txt-danger">{error}</p>
+                    {/* Invisible Turnstile widget */}
+                    <div id="cf-turnstile" className="hidden" />
+
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      disabled={loading || !email || !!rateLimitedUntil}
+                      className="w-full justify-center py-2"
+                    >
+                      {loading
+                        ? "Sending…"
+                        : rateLimitedUntil
+                          ? `Rate limited | Retry in ${countdown}s`
+                          : "Send code"}
+                    </Button>
+                  </form>
+                ) : (
+                  <form
+                    onSubmit={handleOtpSubmit}
+                    className="flex flex-col gap-4"
+                  >
+                    <div className="flex flex-col gap-1.5">
+                      <div className="flex items-center justify-between gap-3">
+                        <label
+                          htmlFor="otp-0"
+                          className="text-body-sm font-medium text-txt-black-900"
+                        >
+                          One-time passcode
+                        </label>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={handlePasteOtp}
+                          className="px-2 py-1 text-body-sm"
+                          icon={<ClipboardDocumentIcon className="h-4 w-4" />}
+                        >
+                          Paste
+                        </Button>
+                      </div>
+                      <div
+                        className={clx(
+                          "grid grid-cols-8 overflow-hidden rounded-md border bg-bg-white",
+                          error ? "border-txt-danger" : "border-otl-gray-200",
+                        )}
+                      >
+                        {otp.map((digit, index) => (
+                          <input
+                            key={index}
+                            id={index === 0 ? "otp-0" : undefined}
+                            ref={(el) => {
+                              otpInputRefs.current[index] = el;
+                            }}
+                            type="text"
+                            inputMode="numeric"
+                            required
+                            autoComplete={index === 0 ? "one-time-code" : "off"}
+                            aria-label={`Passcode digit ${index + 1}`}
+                            value={digit}
+                            onChange={(e) =>
+                              handleOtpChange(index, e.target.value)
+                            }
+                            onKeyDown={(e) => handleOtpKeyDown(index, e)}
+                            onPaste={(e) => {
+                              e.preventDefault();
+                              applyOtpDigits(
+                                e.clipboardData.getData("text"),
+                                index,
+                              );
+                            }}
+                            className={clx(
+                              "h-12 w-full border-0 text-center font-mono text-2xl font-semibold text-txt-black-900 sm:h-14 sm:text-3xl",
+                              "bg-bg-white outline-none transition",
+                              "focus:border-otl-gray-400 focus:ring-primary/20 focus:ring-2",
+                              index < OTP_LENGTH - 1 &&
+                                "border-r border-otl-gray-200",
+                            )}
+                          />
+                        ))}
+                      </div>
+                    </div>
+
+                    {error && (
+                      <p className="text-body-sm text-txt-danger">{error}</p>
+                    )}
+
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      disabled={loading || otpValue.length !== OTP_LENGTH}
+                      className="w-full justify-center py-2"
+                    >
+                      {loading ? "Verifying…" : "Continue"}
+                    </Button>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setStep("email");
+                        resetOtp();
+                        setError(null);
+                      }}
+                      className="text-body-sm text-txt-black-500 underline-offset-2 hover:text-txt-black-900 hover:underline"
+                    >
+                      Use a different email
+                    </button>
+                  </form>
                 )}
-
-                <Button
-                  type="submit"
-                  variant="primary"
-                  disabled={loading || otp.length < 4}
-                  className="w-full justify-center py-2"
-                >
-                  {loading ? "Verifying…" : "Continue"}
-                </Button>
-
-                <button
-                  type="button"
-                  onClick={() => {
-                    setStep("email");
-                    setOtp("");
-                    setError(null);
-                  }}
-                  className="text-body-sm text-txt-black-500 underline-offset-2 hover:text-txt-black-900 hover:underline"
-                >
-                  Use a different email
-                </button>
-              </form>
-            )}
-            </>
+              </>
             )}
           </Card>
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   webpack: 5.106.2
   postcss: 8.5.14
+  qs: 6.15.2
 
 importers:
 
@@ -4669,8 +4670,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -6508,7 +6509,7 @@ snapshots:
   '@duckdb/duckdb-wasm@1.33.1-dev45.0':
     dependencies:
       apache-arrow: 17.0.0
-      qs: 6.15.1
+      qs: 6.15.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -10810,7 +10811,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
Replace the single OTP field with an 8-slot segmented control, add paste support, require a complete code before submit, and tune the digit sizing for a clearer verification flow.